### PR TITLE
Add KeepRule - AI Investment Discipline Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -3974,6 +3974,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 14. [TradeUI](https://tradeui.com/) 👉 Options Flow and Stock Market trading tools - TradeUI
 
+15. [KeepRule](https://keeprule.com/) 👉 AI-powered investment discipline tracking with principles from 26 legendary investors including Buffett, Munger, and Dalio. Features scenario analysis and psychological tests.
+
 ## 29. <a name='FashionStyle'></a>👜 Fashion & Style
 
 1. [AweMyFace](https://apps.apple.com/app/apple-store/id1621101995) 👉 AweMyFace — is a skincare app and your only guide on the way to the perfect skin.


### PR DESCRIPTION
## Summary

- Adds [KeepRule](https://keeprule.com) to the **Finance** section (#28)
- KeepRule is an AI-powered investment discipline tracking platform featuring principles from 26 legendary investors including Buffett, Munger, and Dalio
- Features scenario analysis and psychological tests for investors

## Why it fits this list

KeepRule is a perfect fit for the Finance section alongside existing tools like AlphaResearch, TradeUI, and Gorilla AI. It uses AI to help investors maintain discipline by tracking proven investment principles from legendary investors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)