### PR TITLE
Add Nex.ai — context engineering platform for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1344,6 +1344,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 118. [BurnRate](https://getburnrate.io/) 👉 AI coding cost analytics CLI that tracks usage and costs across Claude Code, Cursor, Copilot, Windsurf, Aider, Cline, and Codex with real-time dashboard and 46 optimization rules.
 
+119. [Nex.ai](https://nex.ai) 👉 Context engineering platform that gives AI agents real-time organizational context from CRM, email, Slack, and data warehouses. REST API with SSE streaming.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
## What is Nex.ai?

[Nex.ai](https://nex.ai) is a context engineering platform that gives AI agents real-time organizational context from CRM, email, Slack, and data warehouses.

## Why add it?

It solves the production AI deployment problem — agents that work in demos but fail with real organizational data because they can't access live CRM records, email threads, or Slack context. Nex provides this context layer via REST API + SSE streaming.

- Works with LangChain, LlamaIndex, CrewAI, Claude, ChatGPT, and any HTTP-capable agent
- SOC2 Type 1 certified
- Founded 2024 by HubSpot alumni

Added under **Dev** section as a developer tool.