### PR TITLE
Add MaxVideoAI to Video category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1743,6 +1743,8 @@ Join 2700+ creators to reach billions of people globally
 
 92. [YouWhisper](https://huggingface.co/spaces/sensahin/YouWhisper) 👉 Discover amazing ML apps made by the community
 
+93. [MaxVideoAI](https://maxvideoai.com/models) 👉 Multi-engine AI video model catalog with specs, pricing, examples, and engine comparisons across Sora, Veo, Kling, Seedance, Wan, LTX, and Pika.
+
 ## 6. <a name='Design'></a>🎨 Design
 
 1. [Adobe Sensei](https://www.adobe.com/sensei.html) 👉 Power incredible experiences with AI.


### PR DESCRIPTION
Adds MaxVideoAI to the Video category with a deep link to the public models catalog.