### PR TITLE
feat: add ArtImageHub to Image Editing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2125,6 +2125,8 @@ Join 2700+ creators to reach billions of people globally
 
 71. [Moire Removal](https://moireremoval.com/) 👉 AI-powered moiré pattern removal tool for screen photos, scanned prints, and projector captures. Preserves text legibility and facial details.
 
+72. [ArtImageHub](https://artimagehub.com/old-photo-restoration) 👉 AI-powered old photo restoration. Fixes scratches, fading, blur, and water damage on old family photos. One-time $4.99, no subscription.
+
 ## 8. <a name='TextSpeech'></a>🗣️ Text & Speech
 
 1. [AI Alfred](https://www.theaialfred.com/) 👉 Summarize what you want in 1 single click, using AI


### PR DESCRIPTION
## Summary

- Adds [ArtImageHub](https://artimagehub.com/old-photo-restoration) as entry #72 in the **📷 Image Editing** section
- Tool description: AI-powered old photo restoration that fixes scratches, fading, blur, and water damage on old family photos
- Pricing model: one-time \$4.99, no subscription — consistent with other commercial tools already listed (Clipdrop, Cutout Pro, Gigapixel AI)

## Test plan

- [ ] Verify the link https://artimagehub.com/old-photo-restoration is live and resolves correctly
- [ ] Confirm entry format matches existing entries in Section 7 (`[Name](URL) 👉 Description`)
- [ ] Confirm no duplicate entry exists in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)