### PR TITLE
Add AdDogs to eCommerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -3891,6 +3891,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 19. [Zevi](https://www.zevi.ai/) 👉 Zevi is an neural search engine for ecommerce brands. It enables website's search and merchandising functionality, improving user experience, and sales performance.
 
+20. [AdDogs](https://www.addogs.ai/) 👉 AI ad creative generator for e-commerce and DTC brands. Clone any winning ad design, swap in your product photo, and apply your brand colors and logo in seconds. Exports in 14 aspect ratios for Instagram, TikTok, Facebook, and Google.
+
 ## 25. <a name='Gaming'></a>🕹 Gaming
 
 1. [AI Dungeon](https://play.aidungeon.io/) 👉 AI Dungeon, an infinitely generated text adventure powered by deep learning


### PR DESCRIPTION
Adds [AdDogs](https://www.addogs.ai) to the 🛍️ eCommerce section.

**What it is:** AI ad creative generator built for e-commerce and DTC brands. Pick any winning ad design, upload your product photo, and the AI recreates the ad with your product — preserving the original layout, style, and composition. Brand colors and logo are extracted automatically.

**Why eCommerce:** Sits naturally alongside Mokker, Flair, and Free Product Photo Visualizer in this section — generative product visuals — but specialized for full ad creatives across 14 aspect ratios for Instagram, TikTok, Facebook, and Google.

Real, public, working product. Free tier available; paid plans from $12/mo. Happy to adjust placement or wording. Thanks for maintaining this list.