### PR TITLE
Add Parse to SEO & Searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3399,6 +3399,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 264. [toprank](https://github.com/nowork-studio/toprank) 👉 Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and Google Ads API; rewrites meta tags, generates JSON-LD schema markup, and ships fixes directly to WordPress, Strapi, Contentful, or Ghost. 107 stars.
 
+265. [Parse](https://parse.gl/) 👉 AI brand visibility analytics that tracks how your brand appears in ChatGPT and Google AI Overviews. Parse Score benchmarks, citation diagnostics, and 577,000+ brands tracked.
+
 ## 17. <a name='JobCareer'></a>🧑‍💼 Job & Career
 
 1. [Ada](https://app.adaptiv.me/app/ask-ada) 👉 Adaptiv Academy


### PR DESCRIPTION
Adds Parse to section 16 (SEO & Searching).

Parse (https://parse.gl/) tracks how brands appear in ChatGPT and Google AI Overviews, with Parse Score benchmarks, citation diagnostics, and 577,000+ brands tracked. Closest neighbours in the existing section are RankRaven (#8), SEOfor.AI (#32), and evalmyBRAND (#57).