### PR TITLE
Add EuroForge AI Cost Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4036,6 +4036,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 15. [KeepRule](https://keeprule.com/) 👉 AI-powered investment discipline tracking with principles from 26 legendary investors including Buffett, Munger, and Dalio. Features scenario analysis and psychological tests.
 
+16. [EuroForge AI Cost Calculator](https://euroforge-autopilot.vercel.app/chatgpt-team-cost-calculator/?utm_source=awesome_ai_tools) 👉 Estimate wasted ChatGPT Team seats, duplicate AI subscriptions, and LLM API spend.
+
 ## 29. <a name='FashionStyle'></a>👜 Fashion & Style
 
 1. [AweMyFace](https://apps.apple.com/app/apple-store/id1621101995) 👉 AweMyFace — is a skincare app and your only guide on the way to the perfect skin.


### PR DESCRIPTION
Adds EuroForge AI Cost Calculator to the Finance section.

The linked page is a live AI spend calculator for estimating wasted ChatGPT Team seats, duplicate AI subscriptions, and LLM API spend.

Validation:
- `git diff --check`
- Live URL returns HTTP 200
- README secret scan found no tokens or private keys
