### PR TITLE
Add AnySlide to Writing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,8 @@ Describe the problem your product/service solves. Help the bot with top level in
 
 248. [Humanizer PRO](https://texthumanizer.pro) 👉 Humanizer PRO is an AI text humanizer that transforms AI-generated content into natural, human-sounding text that bypasses AI detectors. Features stealth, academic, and SEO modes. Available as web app and MCP server for ChatGPT, Claude, Cursor.
 
+249. [AnySlide](https://anyslide.app) 👉 AI slide deck generator with two engines: HTML inline-editable web slides and gpt-image-2 full-image rendering with native Chinese, Japanese, and Korean text support. 38 templates, 8 niche presets, 60 free credits at signup.
+
 ## 3. <a name='Dev'></a>💻 Dev
 
 1. [Adept](https://www.adept.ai/) 👉 ML research and product lab building general intelligence by enabling humans and computers to work together creatively.


### PR DESCRIPTION
Hi @pingan8787! Adding **AnySlide** to the ✍️ Writing section, alongside Tome (#211) and other slide-adjacent tools.

### What it is
An AI slide deck generator that turns articles, links, or PDFs into a full presentation in ~30 seconds. Two rendering engines:

- **HTML path** — outputs inline-editable web slides (reveal.js / Slidev style)
- **gpt-image-2 path** — renders each page as a full image with **native Chinese / Japanese / Korean text support**, solving the garbled-CJK problem that affects most AI image tools

### Quality / Live
- ✅ Public site, no waitlist
- ✅ Functional and usable today
- ✅ 60 free credits at signup, daily +10 reset, no credit card required
- ✅ Live URL: https://anyslide.app
- 38 templates, 8 vertical-specific presets

### Disclosure
I'm the maker of AnySlide — filing this myself because the CJK-rendering angle isn't represented elsewhere in the Writing section, and I think it'd be a useful complement to Tome and other slide tools.

Thanks for maintaining the list!