### PR TITLE
Add MartinLoop to Dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,6 +1376,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 127.  [KubeStellar Console](https://github.com/kubestellar/console) 👉 Multi-cluster Kubernetes dashboard with AI-powered operations via MCP. Includes kc-agent for bridging AI coding agents (Claude, Copilot, Codex) to the Kubernetes API for natural-language cluster management, CNCF project integrations, and real-time observability across edge and cloud clusters.
 
+128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
## Summary
- add MartinLoop to the Dev section of the awesome list
- use the product homepage and a short description focused on AI coding agent governance

## Why this fits
MartinLoop is a developer-facing tool for autonomous AI coding agents, which matches the existing Dev section entries for CLIs, MCP servers, and agent tooling.