### PR TITLE
Add Korra to Chatbots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2459,6 +2459,8 @@ Join 2700+ creators to reach billions of people globally
 
 78. [RemoteOpenClaw](https://remoteopenclaw.com) 👉 Open marketplace for AI skills and personas built on OpenClaw. Discover, share, and sell AI agent skills and personas.
 
+79. [Korra](https://korra.finance/groups) 👉 AI markets analyst that lives in your Telegram group as a member, not a tool. Multi-domain takes (macro, on-chain, news, sentiment) with per-group personality dials. Built by an ex-eToro Senior Market Analyst (CySEC Advanced). Free during early access.
+
 ## 10. <a name='ResearchEducation'></a>📚 Research & Education
 
 1. [AI Alfred](https://www.theaialfred.com/) 👉 Summarize what you want in 1 single click, using AI


### PR DESCRIPTION
Korra is an AI markets analyst that lives in a Telegram group as a member, not a tool. Multi-domain (macro + on-chain + news + sentiment), per-group personality dials. Built by Mati Greenspan (7.5y at eToro, CySEC Advanced). Free during early access. Appended as #79 in the Chatbots section following the same pattern as the most recent merged PR (Sistava #105 in Business).