### PR TITLE
Add GenOps Framework to Dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
 
+129.  [GenOps Framework](https://github.com/neerazz/genops-framework) 👉 Open-source (MIT) governance and operations framework for LLM/agent pipelines — adds policy enforcement, cost controls, and observability hooks so generative-AI workloads run with auditable guardrails in CI/CD.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
Adds **GenOps Framework** to the Dev section (entry 129).

[GenOps Framework](https://github.com/neerazz/genops-framework) is an open-source (MIT) governance and operations framework for LLM/agent pipelines — it adds policy enforcement, cost controls, and observability hooks so generative-AI workloads run with auditable guardrails in CI/CD. Fits alongside the recent control-plane / agent-ops entries (MartinLoop, KubeStellar Console).

- One-line addition, matches the existing numbered list format.
- Open source, MIT licensed.

Thanks for maintaining this list!