### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4048,6 +4048,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 15. [KeepRule](https://keeprule.com/) 👉 AI-powered investment discipline tracking with principles from 26 legendary investors including Buffett, Munger, and Dalio. Features scenario analysis and psychological tests.
 
+16. [TWZRD Agent Intel](https://intel.twzrd.xyz) 👉 Solana-native x402 MCP server for AI agent trust scoring. Free: score_agent, preflight_check. Paid: signed trust receipt via HTTP 402 + USDC. MCP endpoint: https://intel.twzrd.xyz/mcp
+
 ## 29. <a name='FashionStyle'></a>👜 Fashion & Style
 
 1. [AweMyFace](https://apps.apple.com/app/apple-store/id1621101995) 👉 AweMyFace — is a skincare app and your only guide on the way to the perfect skin.


### PR DESCRIPTION
## Summary

Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** to the Finance section.

- MCP endpoint: `https://intel.twzrd.xyz/mcp` (streamable-HTTP, zero install)
- Free tools: `score_agent(wallet)`, `preflight_check(wallet)` — Solana wallet trust scores
- Paid: `get_trust_receipt` via HTTP 402 + USDC micropayment on Solana