### PR TITLE
Add promptvv (video-to-prompt) to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1790,6 +1790,8 @@ Join 2700+ creators to reach billions of people globally
 
 96. [HeyVid](https://heyvid.ai) 👉 All-in-one AI video and image generator with text-to-image and text-to-video in a single workspace.
 
+97. [promptvv](https://promptvv.com) 👉 Reverse-engineers any video (or a Douyin/Xiaohongshu/Bilibili link) into structured AI video prompts — events, shots, camera moves, performance, and dialogue — ready to paste into Jimeng, Seedance, and Kling.
+
 ## 6. <a name='Design'></a>🎨 Design
 
 1. [Adobe Sensei](https://www.adobe.com/sensei.html) 👉 Power incredible experiences with AI.


### PR DESCRIPTION
Adds **promptvv** to the **🎥 Video** section as #97 (appended at the end of the section, same style as recent entries #94–96).

**What it is:** promptvv reverse-engineers any video into structured AI video prompts — events, shots, camera moves, performance, and dialogue — ready to paste into AI video generators (Jimeng / Seedance / Kling) to recreate it.

**Why it fits:** A video → prompt tool; notably it accepts Douyin / Xiaohongshu / Bilibili links and returns a shot-by-shot structured breakdown rather than a single prompt string. Live and free to try (free quota on signup).

Thanks for maintaining the list!