### PR TITLE
Add ArtImageHub to Image Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2032,7 +2032,7 @@ Join 2700+ creators to reach billions of people globally
 
 1. [Artbreeder](https://www.artbreeder.com/) 👉 Artbreeder
 
-1. [ArtImageHub](https://artimagehub.com/old-photo-restoration) 👉 Online AI tool to restore, colorize and enhance old or damaged photos; free preview, $4.99 per download
+1. [ArtImageHub](https://artimagehub.com/old-photo-restoration) 👉 Online AI tool to restore, colorize and enhance old or damaged photos; $4.99 one-time, no subscription
 
 1. [Astria.ai](https://www.astria.ai/) 👉 Create custom images using AI
 

--- a/README.md
+++ b/README.md
@@ -2032,6 +2032,8 @@ Join 2700+ creators to reach billions of people globally
 
 1. [Artbreeder](https://www.artbreeder.com/) 👉 Artbreeder
 
+1. [ArtImageHub](https://artimagehub.com/old-photo-restoration) 👉 Online AI tool to restore, colorize and enhance old or damaged photos; free preview, $4.99 per download
+
 1. [Astria.ai](https://www.astria.ai/) 👉 Create custom images using AI
 
 1. [Audo AI](https://audo.ai/) 👉 One click audio cleaning for YouTubers and Podcasters ️


### PR DESCRIPTION
Adds **ArtImageHub** to the *📷 Image Editing* category (placed alphabetically after Artbreeder).

- One tool, one entry, alphabetical placement matching the existing list convention.
- ArtImageHub is an online AI tool for restoring, colorizing and enhancing old or damaged photos (free preview, $4.99 per download).
- Link: https://artimagehub.com/old-photo-restoration

Thanks for maintaining this list!