### PR TITLE
Add Xianyu Cover Copy Generator to eCommerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -3910,6 +3910,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 19. [Zevi](https://www.zevi.ai/) 👉 Zevi is an neural search engine for ecommerce brands. It enables website's search and merchandising functionality, improving user experience, and sales performance.
 
+20. [Xianyu Cover Copy Generator](https://ronnie2025.github.io/xianyu-cover-copy-generator/) 👉 Free browser-side generator for marketplace listing cover copy, detail-image structure, imagegen prompts, and post-listing tracking fields.
+
 ## 25. <a name='Gaming'></a>🕹 Gaming
 
 1. [AI Dungeon](https://play.aidungeon.io/) 👉 AI Dungeon, an infinitely generated text adventure powered by deep learning


### PR DESCRIPTION
## Summary\n\nAdd Xianyu Cover Copy Generator to the eCommerce section. It is a free browser-side utility for marketplace sellers to generate listing cover copy, detail-image structure, imagegen prompts, and post-listing tracking fields.\n\nDemo: https://ronnie2025.github.io/xianyu-cover-copy-generator/\nSource: https://github.com/Ronnie2025/xianyu-cover-copy-generator\n\n## Notes\n\n- Pure static HTML, no backend and no login.\n- The list entry links to the free demo page.\n- The tool avoids QR codes, platform logos, external contact info, and income promises.\n\n## Verification\n\n- Demo page returns HTTP 200.\n- Source repository is public.\n- README change is a single eCommerce-section entry.