### PR TITLE
Add NotFair: open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3413,6 +3413,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 265. [Parse](https://parse.gl/) 👉 AI brand visibility analytics that tracks how your brand appears in ChatGPT and Google AI Overviews. Parse Score benchmarks, citation diagnostics, and 577,000+ brands tracked.
 
+266. [NotFair](https://github.com/nowork-studio/NotFair) 👉 Open-source (MIT) Claude Code skills for SEO, GEO, Google Ads, and Meta Ads (~2.9k stars). Connects live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to power site audits, keyword research, meta-tag generation, schema markup, wasted-spend detection, and creative-fatigue analysis.
+
 ## 17. <a name='JobCareer'></a>🧑‍💼 Job & Career
 
 1. [Ada](https://app.adaptiv.me/app/ask-ada) 👉 Adaptiv Academy


### PR DESCRIPTION
Hi! Thanks for maintaining this list — it's a great resource.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source (MIT) Claude Code plugin focused on SEO and paid-ads work. It has ~2.9k GitHub stars and connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

The skill areas it covers are:
- **SEO/GEO** — site audits, keyword research, meta-tag generation, schema markup, GEO optimization, content writing
- **Google Ads** — wasted-spend detection, search-term cleanup, keyword and bid management
- **Meta Ads** — ROAS analysis, creative fatigue detection, audience overlap

I placed it at the end of the "SEO & Searching" section (item 266), which felt like the most natural fit. Happy to reword the description, adjust the placement, or trim anything that doesn't match your style — just let me know.