### PR TITLE
Add AiToolsObserver to Research & Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -2583,6 +2583,8 @@ Join 2700+ creators to reach billions of people globally
 
 61. [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) 👉 搜索科学论文，从全文研究中提取结构化实验数据。支持 SSE 和 Streamable HTTP。
 
+62. [AiToolsObserver](https://aitoolsobserver.com/) 👉 Discover and compare AI tools, follow emerging AI trends, and explore practical use cases through curated insights.
+
 ## 11. <a name='AvatarsProfilePics'></a>🧑 Avatars & Profile Pics
 
 1. [AI Photos](https://aiphotos.ai/) 👉 Get 150+ AI generated photos in 50+ styles for her, him, and couples.


### PR DESCRIPTION
## What changed

Adds AiToolsObserver to **Research & Education**.

AiToolsObserver helps users research and compare AI tools, follow emerging AI trends, and explore practical use cases through curated insights.

## Disclosure

I am affiliated with AiToolsObserver. The addition follows the repository's numbered entry format.

## Validation

- Confirmed the website is publicly accessible
- Checked that the URL is not already listed
- Ran `git diff --check`