### PR TITLE
Add LoopTroop to Dev section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
 
+129.  [LoopTroop](https://github.com/looptroop-ai/LoopTroop) 👉 Local-first open-source GUI app that orchestrates an LLM Council through Ralph Loops and Context Engineering to autonomously run full-lifecycle coding tickets. Multiple models plan via anonymous voting, work splits into atomic Beads in isolated git worktrees, and Ralph Loops retry failures with fresh context.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
Adding LoopTroop to the Dev section (section 3). It is a local-first, open-source GUI app that runs complex, long-running AI coding tickets from start to finish. An LLM Council drafts, anonymously votes, and merges the best ideas to plan. Work is split into atomic Beads run in isolated git worktrees, and Ralph Loops retry failures with fresh context so the model does not drift on long tasks. It runs on the OpenCode harness and supports any model.

Repo: https://github.com/looptroop-ai/LoopTroop
Site: https://www.looptroop.ovh/

Added as entry 129 at the end of the Dev list, matching the existing numbered format.