### PR TITLE
Add cv.cm/v to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1790,6 +1790,8 @@ Join 2700+ creators to reach billions of people globally
 
 96. [HeyVid](https://heyvid.ai) 👉 All-in-one AI video and image generator with text-to-image and text-to-video in a single workspace.
 
+97. [cv.cm/v](https://cv.cm/v) 👉 Queue-free, full-power Seedance 2.0 text-to-video and image-to-video studio with AI image generation, a node-graph canvas, and a REST API. New users get 100 free credits and no signup is required to try it.
+
 ## 6. <a name='Design'></a>🎨 Design
 
 1. [Adobe Sensei](https://www.adobe.com/sensei.html) 👉 Power incredible experiences with AI.


### PR DESCRIPTION
Adds **[cv.cm/v](https://cv.cm/v)** to the 🎥 Video section (entry 97, following the existing numbered format).

cv.cm/v is a queue-free, full-power **Seedance 2.0** text-to-video / image-to-video studio with AI image generation, a node-graph canvas, and a REST API. 100 free credits, no signup required to try.