### PR TITLE
Add AnswerLens to SEO & Searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3413,6 +3413,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 265. [Parse](https://parse.gl/) 👉 AI brand visibility analytics that tracks how your brand appears in ChatGPT and Google AI Overviews. Parse Score benchmarks, citation diagnostics, and 577,000+ brands tracked.
 
+266. [AnswerLens](https://app.sfdj.net/) 👉 Audits B2B SaaS public website evidence for pricing, proof, docs, comparison, trust, schema, and llms.txt gaps.
+
 ## 17. <a name='JobCareer'></a>🧑‍💼 Job & Career
 
 1. [Ada](https://app.adaptiv.me/app/ask-ada) 👉 Adaptiv Academy


### PR DESCRIPTION
Adds AnswerLens to the SEO & Searching section.

Disclosure: I am connected to AnswerLens. The entry is a single factual listing for a free public scan and optional one-time implementation report. It does not claim rankings, AI citations, traffic, revenue, sponsorship, affiliate status, or any guaranteed outcome.