### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
 
+129.  [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) 👉 Local-first memory lifecycle layer for AI agents with Rust CLI/TUI, SQLite/FTS recall, audit, forgetting, and consolidation.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
## Summary

- Add Tree Ring Memory to the Dev section.
- Link to the canonical open-source GitHub repository.
- Keep the description factual and scoped to agent-memory infrastructure.

## Fit

Tree Ring Memory is a local-first memory lifecycle layer for AI agents. It fits the Dev section beside other AI coding-agent and developer-infrastructure tools because it provides Rust CLI/TUI workflows for recall, audit, forgetting, and consolidation.

## Disclosure

I maintain Tree Ring Memory.

## Checks

- Searched PRs, issues, and README for existing Tree Ring Memory mentions.
- Verified the README contains exactly one Tree Ring Memory entry after the edit.
- Verified the Tree Ring GitHub URL returns HTTP 200.
- Ran `git diff --check`.
