### PR TITLE
Add Podframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1790,6 +1790,8 @@ Join 2700+ creators to reach billions of people globally
 
 96. [HeyVid](https://heyvid.ai) 👉 All-in-one AI video and image generator with text-to-image and text-to-video in a single workspace.
 
+97. [Podframes](https://github.com/Jellypod-Inc/podframes) 👉 Open-source studio and CLI for generating two-host AI podcast videos locally.
+
 ## 6. <a name='Design'></a>🎨 Design
 
 1. [Adobe Sensei](https://www.adobe.com/sensei.html) 👉 Power incredible experiences with AI.


### PR DESCRIPTION
Adds Podframes to the Video section as an open-source studio and CLI for generating two-host AI podcast videos locally.