### PR TITLE
Add Hellomatik to Chatbots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2459,6 +2459,8 @@ Join 2700+ creators to reach billions of people globally
 
 78. [RemoteOpenClaw](https://remoteopenclaw.com) 👉 Open marketplace for AI skills and personas built on OpenClaw. Discover, share, and sell AI agent skills and personas.
 
+79. [Hellomatik](https://hellomatik.com) 👉 AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web.
+
 ## 10. <a name='ResearchEducation'></a>📚 Research & Education
 
 1. [AI Alfred](https://www.theaialfred.com/) 👉 Summarize what you want in 1 single click, using AI


### PR DESCRIPTION
Adds **Hellomatik** to the Chatbots section. AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web. Appended at the end of the numbered list — feel free to reorder. Thanks!