### PR TITLE
Add AI Router to Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
 
+129.  [AI Router](https://ai-router.dev/) 👉 Independent OpenAI-compatible API relay for developers and coding-agent workflows, with personal API keys, per-key usage visibility, and authenticated model discovery.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
## What is AI Router?

[AI Router](https://ai-router.dev/) is an independent OpenAI-compatible API relay for developers and coding-agent workflows.

## Why add it?

It fits the `Dev` section alongside existing API-oriented developer platforms. The entry uses only public, configuration-level facts: personal API keys, per-key usage visibility, and authenticated model discovery.

## Disclosure

I represent AI Router. This is a focused one-line directory submission with no pricing, free-credit, model-inventory, or reliability claims.