### PR TITLE
Add Echo99 to Audio & Voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2830,6 +2830,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 64. [AnveVoice](https://anvevoice.app) 👉 Voice AI agent for websites with agentic DOM actions, MCP support, 50+ languages, <700ms latency. Free tier available.
 
+65. [Echo99](https://www.echo99.app/) 👉 Private macOS call recorder that captures separate microphone and system audio tracks, then transcribes and labels speakers on-device.
+
 ## 13. <a name='TeamWork'></a>🤝 Team & Work
 
 1. [AI Lawyer](https://ailawyer.pro/) 👉 Say goodbye to expensive consultations, long waits for appointments, and confusing legal texts. With the AI-lawyer platform, you can get expert legal advice and document creation/summarizing/comparison tools anytime, anywhere. Our user-friendly interface speaks plain language, so you don't have to be a legal expert to understand your rights and obligations.


### PR DESCRIPTION
## Summary

Add Echo99 to the Audio & Voice section.

Echo99 is a private macOS call recorder that captures microphone and system audio as separate tracks, then transcribes recordings and labels speakers on-device.

## Why it fits

- uses on-device AI for transcription and speaker labeling
- complements the existing recording and transcription tools
- works without a meeting bot or account
- keeps recordings and transcripts on the Mac

## Validation

- `git diff --check`
- confirmed the change is one entry in Audio & Voice
- confirmed the Echo99 website returns HTTP 200
- checked for an existing Echo99 entry or submission
