### PR TITLE
Add YingTu to Image and Art Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,8 @@ Image AI App is a tool that utilizes artificial intelligence (AI) to generate va
 
 278. [Punch Needle Generator](https://www.punchneedle.co.il/en) 👉 AI-powered punch needle embroidery pattern generator with color-coded yarn maps. Generates patterns from text prompts or image uploads, exports PDF/PNG/SVG.
 
+279. [YingTu](https://yingtu.ai/en) 👉 Browser playground for testing AI image and video API routes, prompts, reference inputs, task status, and downloads before integration.
+
 ## 2. <a name='Writing'></a>✍️ Writing
 
 1. [AI Cowriter](https://ai-cowriter.com/) 👉 Write 10x faster with AI-generated autocomplete text suggestions


### PR DESCRIPTION
## Summary

Adds YingTu as item 279 at the end of the Image & Art Generation section.

- Uses the canonical public URL: https://yingtu.ai/en
- Adds one factual description only
- Keeps the existing numbered-entry and blank-line format
- No affiliate links or unrelated edits

## Verification

- The public URL is accessible.
- YingTu and yingtu.ai were not present in the current README.
- The diff contains one tool entry plus the category's standard blank-line separator, with 0 deletions.

Submitting on behalf of the YingTu project. This contribution was prepared with OpenAI Codex assistance. Opening the playground is free; generation requires a valid API key and follows active account and route rules.