### PR TITLE
Add GPTGeminiGrok.AI to Chatbots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2459,6 +2459,8 @@ Join 2700+ creators to reach billions of people globally
 
 78. [RemoteOpenClaw](https://remoteopenclaw.com) 👉 Open marketplace for AI skills and personas built on OpenClaw. Discover, share, and sell AI agent skills and personas.
 
+79. [GPTGeminiGrok.AI](https://trygrokai.asia/) 👉 Multi-model browser workspace for GPT, Gemini, Grok, Claude, and AI image workflows.
+
 ## 10. <a name='ResearchEducation'></a>📚 Research & Education
 
 1. [AI Alfred](https://www.theaialfred.com/) 👉 Summarize what you want in 1 single click, using AI


### PR DESCRIPTION
Adds GPTGeminiGrok.AI to the Chatbots section using the existing numbered format.\n\n- Product: GPTGeminiGrok.AI\n- URL: https://trygrokai.asia/\n- Description: Multi-model browser workspace for GPT, Gemini, Grok, Claude, and AI image workflows.\n- Access: Account required; free usage is limited to 10 requests per day.\n- Relationship: I am the creator/operator of the submitted product.\n\nThis PR adds one concise README entry and does not require payment or a reciprocal link.