### PR TITLE
Add GPT Image 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2459,6 +2459,8 @@ Join 2700+ creators to reach billions of people globally
 
 78. [RemoteOpenClaw](https://remoteopenclaw.com) 👉 Open marketplace for AI skills and personas built on OpenClaw. Discover, share, and sell AI agent skills and personas.
 
+79. [GPT Image 2](https://gptimage2.asia/) 👉 AI image generator and editor for marketing visuals and branded content.
+
 ## 10. <a name='ResearchEducation'></a>📚 Research & Education
 
 1. [AI Alfred](https://www.theaialfred.com/) 👉 Summarize what you want in 1 single click, using AI


### PR DESCRIPTION
Add GPT Image 2 as item 79 in Chatbots.

- Canonical URL: https://gptimage2.asia/
- Description: AI image generator and editor for marketing visuals and branded content.