### PR TITLE
Add Reducto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
 
+129.  [Reducto](https://reducto.ai/) 👉 Agentic document platform for parsing, extracting, classifying, splitting, and editing complex documents via API.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
## Summary
- Add Reducto to the Dev section as an agentic document platform/API.

## Link
- https://reducto.ai/