### PR TITLE
Add Mydentify AI crawler checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3413,6 +3413,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 265. [Parse](https://parse.gl/) 👉 AI brand visibility analytics that tracks how your brand appears in ChatGPT and Google AI Overviews. Parse Score benchmarks, citation diagnostics, and 577,000+ brands tracked.
 
+266. [Mydentify AI Crawler Access Checker](https://mydentify.com/tools/ai-crawler-access-checker) 👉 Check whether common AI crawlers can access a website and review the robots.txt and HTTP response evidence.
+
 ## 17. <a name='JobCareer'></a>🧑‍💼 Job & Career
 
 1. [Ada](https://app.adaptiv.me/app/ask-ada) 👉 Adaptiv Academy


### PR DESCRIPTION
## Summary
- add Mydentify AI Crawler Access Checker to the SEO & Searching section
- link directly to the tool route so readers can inspect crawler-access evidence

## Verification
- target URL returns HTTP 200
- target URL is self-canonical and declares `index, follow`
- entry contains no tracking parameters

## Disclosure
I maintain Mydentify and am proposing this factual entry for editorial review. The contribution requests no reciprocal link, payment, vote, review, or other engagement.