### PR TITLE
Add AI Dictation to Text & Speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -2302,6 +2302,8 @@ Join 2700+ creators to reach billions of people globally
 
 68. [Vocova](https://vocova.app) 👉 AI transcription tool supporting 100+ languages with speaker diarization, URL import from 1000+ platforms, and bilingual side-by-side export.
 
+69. [AI Dictation](https://aidictation.com) 👉 Open-source voice typing for macOS, Windows, iPhone, iPad, and Android, with offline recognition on supported devices plus optional cloud transcription and text cleanup. [Source](https://github.com/writingmate/aidictation).
+
 ## 9. <a name='Chatbots'></a>💬 Chatbots
 
 1. [AI Answers by Cohere](https://cohere.io/) 👉 AI-powered support assistance that finds answers from previous tickets


### PR DESCRIPTION
## Summary

- add one AI Dictation entry to the existing Text & Speech section
- link the canonical product website and MIT-licensed source repository
- use qualified wording for offline recognition and optional cloud features

## Why it belongs

AI Dictation is an open-source voice-typing and speech-to-text app for macOS, Windows, iPhone, iPad, and Android, which fits this section alongside the existing transcription tools.

## Verification

- checked the product description against the current website and repository README
- confirmed the repository is licensed under MIT
- confirmed both submitted links return HTTP 200
- searched the README, open and closed pull requests, and issues for duplicates
- ran `git diff --check`

## Disclosure

I am affiliated with AI Dictation and am submitting the project openly rather than presenting this as an independent recommendation. This entry and pull-request text were prepared with AI assistance and manually checked against the repository's current contribution instructions and product behavior.
