### PR TITLE
Add VisionBoard to Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -2014,6 +2014,8 @@ Join 2700+ creators to reach billions of people globally
 
 126. [Image3D](https://image3d.io/) 👉 Convert images into 3D assets with GLB, OBJ, STL, and PLY exports.
 
+127. [VisionBoard](https://visionboard.bemooore.com/) 👉 Turn a written goal into a personal vision board, a matching phone lock-screen wallpaper, and one concrete next step in about 5 minutes.
+
 ## 7. <a name='ImageEditing'></a>📷 Image Editing
 
 1. [Igly](https://igly.ai/) 👉 Free AI image editor for e-commerce and content teams with background removal, image generation, upscale, restore, inpaint, and canvas editing


### PR DESCRIPTION
Adds VisionBoard as entry 127 at the end of section **6. Design**, following the existing `N. [Name](url) 👉 Description` format.

Type a goal in plain words, get a vision board plus a matching phone lock-screen wallpaper and one concrete next step. Free preview, one-time EUR 8.99 unlock, no subscription.

---
Disclosure: I build VisionBoard. Happy to adjust the wording, category or drop the entry if it is not a fit.
