### PR TITLE
Add IELTS Writing Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,8 @@ Describe the problem your product/service solves. Help the bot with top level in
 
 249. [AnySlide](https://anyslide.app) 👉 AI slide deck generator with two engines: HTML inline-editable web slides and gpt-image-2 full-image rendering with native Chinese, Japanese, and Korean text support. 38 templates, 8 niche presets, 60 free credits at signup.
 
+250. [IELTS Writing Checker](https://ieltswritingchecker.org/) 👉 Reviews IELTS Academic Task 1, General Training Task 1, and Task 2 writing with criterion-specific feedback and revision guidance. [Freemium]
+
 ## 3. <a name='Dev'></a>💻 Dev
 
 1. [Adept](https://www.adept.ai/) 👉 ML research and product lab building general intelligence by enabling humans and computers to work together creatively.


### PR DESCRIPTION
## Summary

- add IELTS Writing Checker to the Writing section
- describe its IELTS-specific feedback and freemium availability

## Why

The list already includes general writing assistants and an IELTS essay-scoring tool. IELTS Writing Checker adds coverage for Academic Task 1, General Training Task 1, and Task 2, with criterion-specific feedback and revision guidance.

Disclosure: I maintain IELTS Writing Checker.

## Validation

- confirmed the website returns HTTP 200
- ran `git diff --check`
- confirmed the URL is not already present in this repository
