### PR TITLE
Add SandBase CLI to Dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
 
+129.  [SandBase CLI](https://github.com/sandbaseai/cli) 👉 Apache-2.0 CLI and MCP bridge that connects 17+ coding-agent clients to a hosted catalog of 2,000+ models and APIs through six discovery and execution tools.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
## What

Adds SandBase CLI to the Dev section using the existing numbered, one-line format.

## Why

SandBase CLI is an Apache-2.0 CLI and MCP bridge for supported coding agents. It exposes six tools for discovering, inspecting, invoking, and tracking calls to a hosted catalog of 2,000+ models and APIs.

Usage signal: the published `@sandbaseai/cli` package recorded 1,776 downloads in the latest completed monthly reporting window and 109 in the latest completed week.

## Validation

- Entry number follows the current end of the Dev list
- GitHub URL is public and accessible
- `git diff --check` passes

Disclosure: I am affiliated with SandBase. AI assistance was used to prepare this contribution.