### PR TITLE
Add videos.social to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1790,6 +1790,8 @@ Join 2700+ creators to reach billions of people globally
 
 96. [HeyVid](https://heyvid.ai) 👉 All-in-one AI video and image generator with text-to-image and text-to-video in a single workspace.
 
+97. [videos.social](https://videos.social/?utm_source=pingan-awesome-ai-tools&utm_medium=directory&utm_campaign=listing-wave-d) 👉 Turns blogs, PDFs, and prompts into editable faceless videos. 1 free render. 1 credit = 1 render.
+
 ## 6. <a name='Design'></a>🎨 Design
 
 1. [Adobe Sensei](https://www.adobe.com/sensei.html) 👉 Power incredible experiences with AI.


### PR DESCRIPTION
Adds videos.social under **🎥 Video**, at the end of the category next to Fliki / Lumen5 / HeyVid.

videos.social turns blogs, PDFs, and prompts into editable faceless videos (script, scenes, voiceover) rather than a locked regenerate loop. Start free — 1 render included. Packs from $10. 1 credit = 1 render.

Public, usable product in the same class as Fliki (blog/script to video) and Lumen5. Not a duplicate.

Disclosure: submitted by the videos.social team.