### PR TITLE
Add PixGT to eCommerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -3896,7 +3896,9 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 12. [Mokker](https://mokker.ai/) 👉 AI-Powered Photo Generation for E-Commerce
 
-13. [Plink](https://www.plink.ai/) 👉 AI powered transactions
+13. [PixGT](https://pixgt.cn) 👉 AI visual engine for e-commerce and cross-border sellers. Turns a white-background product photo into commercial-style scene images, and also handles clothing try-on, model swapping, jewelry and accessory try-on, and pose variations. Free credits on signup.
+
+14. [Plink](https://www.plink.ai/) 👉 AI powered transactions
 
 14. [RegisAI](https://regisai.com/) 👉 Start your 7-day free trial
 


### PR DESCRIPTION
在 24. eCommerce 分区新增 PixGT，按字母序插在 Mokker 和 Plink 之间，后面的编号已顺延。

PixGT (https://pixgt.cn) 是面向跨境电商卖家的 AI 视觉工具：上传白底商品图生成商业级场景图，另外支持服装模特试穿、模特替换、珠宝配饰试戴和姿势裂变。有免费额度。

利益相关声明：我是 PixGT 团队成员。描述文案或分区位置如果需要调整，我可以改。