### PR TITLE
Add SEELE TV to video tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1790,6 +1790,8 @@ Join 2700+ creators to reach billions of people globally
 
 96. [HeyVid](https://heyvid.ai) 👉 All-in-one AI video and image generator with text-to-image and text-to-video in a single workspace.
 
+97. [SEELE TV](https://seele.tv/) 👉 Cinematic AI video studio with scene consistency and shot-level camera control.
+
 ## 6. <a name='Design'></a>🎨 Design
 
 1. [Adobe Sensei](https://www.adobe.com/sensei.html) 👉 Power incredible experiences with AI.


### PR DESCRIPTION
Adds SEELE TV to the Video section using the existing list format.\n\nSEELE TV is a cinematic AI video studio focused on scene consistency and shot-level camera control. The entry links to the official product site and uses a concise, factual description.