### PR TITLE
Add AdMapix to SEO & Searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3413,6 +3413,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 265. [Parse](https://parse.gl/) 👉 AI brand visibility analytics that tracks how your brand appears in ChatGPT and Google AI Overviews. Parse Score benchmarks, citation diagnostics, and 577,000+ brands tracked.
 
+266. [AdMapix](https://www.admapix.com/) 👉 Search competitor ad creatives by keyword, country, date, creative type, and industry through a public MCP server and OpenClaw skill.
+
 ## 17. <a name='JobCareer'></a>🧑‍💼 Job & Career
 
 1. [Ada](https://app.adaptiv.me/app/ask-ada) 👉 Adaptiv Academy


### PR DESCRIPTION
Adds AdMapix to the SEO & Searching section. The entry describes the public MCP server and OpenClaw skill for competitor ad creative research, including keyword, country, date, creative type, and industry filters, and links to the official site.

Disclosure: I maintain the AdMapix project and am submitting this entry for review.