### PR TITLE
Add CreateForge AI to Video tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1790,6 +1790,8 @@ Join 2700+ creators to reach billions of people globally
 
 96. [HeyVid](https://heyvid.ai) 👉 All-in-one AI video and image generator with text-to-image and text-to-video in a single workspace.
 
+97. [CreateForge AI](https://createforgeai.com/) 👉 Multi-model AI image and video workspace with Seedance 2.5, Veo 3.1, GPT Image 2, parameter-aware credit quotes, reference workflows, and saved results.
+
 ## 6. <a name='Design'></a>🎨 Design
 
 1. [Adobe Sensei](https://www.adobe.com/sensei.html) 👉 Power incredible experiences with AI.


### PR DESCRIPTION
## Summary

- Add CreateForge AI to the Video section.
- Use the clean canonical homepage and a concise, objective description of its multi-model image and video workflow.

## Why it fits

CreateForge AI supports image and video creation across Seedance 2.5, Veo 3.1, and GPT Image 2, including reference workflows, parameter-aware credit quotes, and saved results. This matches the existing multi-model video platforms in this section.

## Checks

- The public URL returns HTTP 200.
- No existing CreateForge entry was found.
- The change adds one tool entry and no tracking parameters.
- `git diff --check` passes.

## Disclosure

I am associated with CreateForge AI and am submitting this listing transparently.