### PR TITLE
Add SandBase CLI to Dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
 
+129.  [SandBase CLI](https://github.com/sandbaseai/cli) 👉 Apache-2.0 CLI and MCP bridge connecting 25 AI client targets to 2,000+ models and APIs through six discovery and execution tools.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
## Summary

Adds one SandBase CLI entry to the **Dev** section using the current next sequence number.

This replaces #209, which GitHub automatically closed when its temporary fork was deleted; it was not rejected by a maintainer. The restored submission is rebased on current `main` and updates the verified client count from 17+ to 25 targets.

## Verification

- Public Apache-2.0 source: https://github.com/sandbaseai/cli
- npm package: https://www.npmjs.com/package/@sandbaseai/cli
- Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.sandbaseai%2Fcli/versions/0.1.17
- Six documented MCP tools
- Explicit adapters for Codex, Claude Code, Cursor, Windsurf, Gemini CLI, OpenCode, and other clients
- `git diff --check` passes

Disclosure: I am affiliated with SandBase. This factual submission was prepared with AI assistance and checked against the public source and registries.