### PR TITLE
docs: add SandBase CLI to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
 
+129.  [SandBase CLI](https://github.com/sandbaseai/cli) 👉 Open-source CLI and MCP bridge for discovering and running 2,000+ AI models and APIs through supported AI clients.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
## Summary
- add SandBase CLI as a developer tool
- link the canonical repository and describe its MCP bridge for 2,000+ AI models and APIs

Disclosure: I contribute to SandBase CLI. This is a factual self-submitted entry based on the public project documentation.