### PR TITLE
Add HelloGen to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1790,6 +1790,8 @@ Join 2700+ creators to reach billions of people globally
 
 96. [HeyVid](https://heyvid.ai) 👉 All-in-one AI video and image generator with text-to-image and text-to-video in a single workspace.
 
+97. [HelloGen](https://hellogen.ai/) 👉 A studio that puts a dozen image and video models behind one assistant. Images are unlimited and watermark-free on a free account; video spends credits, and the exact price is shown before each clip renders.
+
 ## 6. <a name='Design'></a>🎨 Design
 
 1. [Adobe Sensei](https://www.adobe.com/sensei.html) 👉 Power incredible experiences with AI.


### PR DESCRIPTION
Adding [HelloGen](https://hellogen.ai/) to the **🎥 Video** section as entry 97.

**Entry:**
`97. [HelloGen](https://hellogen.ai/) 👉 An AI image and video generator that picks a model for your request and quotes the price before rendering, with unlimited watermark-free images on the free tier.`

**What it is:** a hosted studio that runs several image and video models (Seedream, Nano Banana, GPT Image 2, Veo, Kling, Seedance) behind one assistant. You describe the job in plain language, the assistant picks a model and shows the price before anything renders, and failed generations aren't charged. Images are unlimited and watermark-free on the free tier, with a commercial license on outputs.

Appended to the end of the section following the existing `N. [Name](url) 👉 description` numbering. No other changes.