### PR TITLE
Add XiuRouter to Dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ Automatically generate code from scratch, ask questions, get explanations, refac
 
 128.  [MartinLoop](https://martinloop.com/) 👉 Control plane for autonomous AI coding agents with budget caps, policy checks, verifier gates, rollback evidence, and inspectable run records.
 
+129.  [XiuRouter](https://router.xiu.ai/) 👉 Multi-model API service for applications and AI agents with protocol-specific OpenAI Responses and Chat Completions, Anthropic Messages, and Gemini GenerateContent, scoped API keys, and request-level usage and cost records.
+
 ## 4. <a name='Business'></a>👔 Business
 
 1. [AI Review Reply Assistant](https://www.mara-solutions.com/) 👉 AI review response generator: Reply easier and faster than ever to every customer review with individual answers written by your personal AI assistant. No templates needed.


### PR DESCRIPTION
## Summary

- Add XiuRouter as item 129 in the Dev section.
- Follow the existing numbered entry and short-description format.
- Describe protocol-specific model API access, scoped keys, and request-level usage/cost records without promotional savings claims.

## Why it fits

The Dev section already includes AI API and multi-model application services such as Eden AI, One AI, and AI/ML API. XiuRouter serves the same developer audience while preserving OpenAI Responses and Chat Completions, Anthropic Messages, and Gemini GenerateContent as protocol-specific endpoints.

## Verification

- Product URL returns HTTP 200.
- No existing XiuRouter or router.xiu.ai entry, issue, or pull request was found.
- The change is one README entry and does not modify archived yearly lists.

## Disclosure

I work on XiuRouter at XiuLab Inc. This is a self-submission, and AI assistance was used to prepare the wording.