### PR TITLE
Add StudyArena to Research and Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -2583,6 +2583,8 @@ Join 2700+ creators to reach billions of people globally
 
 61. [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) 👉 搜索科学论文，从全文研究中提取结构化实验数据。支持 SSE 和 Streamable HTTP。
 
+62. [StudyArena](https://studyarena.com) 👉 Students compare three anonymous AI answers to one question, vote for the most useful response, then reveal the models.
+
 ## 11. <a name='AvatarsProfilePics'></a>🧑 Avatars & Profile Pics
 
 1. [AI Photos](https://aiphotos.ai/) 👉 Get 150+ AI generated photos in 50+ styles for her, him, and couples.


### PR DESCRIPTION
## Summary

Adds StudyArena to Research & Education.

I've been building StudyArena for students who want a clearer way to compare AI answers. It shows three responses without model names, lets the student choose the most useful one, and reveals the models afterward.

I placed the entry at the end of the section to match the existing numbered format.