### PR TITLE
Add LLM Pulse to SEO & Searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3413,6 +3413,8 @@ Altered AI is ideal for anyone who needs high-quality voice content for their br
 
 265. [Parse](https://parse.gl/) 👉 AI brand visibility analytics that tracks how your brand appears in ChatGPT and Google AI Overviews. Parse Score benchmarks, citation diagnostics, and 577,000+ brands tracked.
 
+266. [LLM Pulse](https://llmpulse.ai/) 👉 Tracks brand mentions, citations, sentiment, and competitor share of voice across AI search engines.
+
 ## 17. <a name='JobCareer'></a>🧑‍💼 Job & Career
 
 1. [Ada](https://app.adaptiv.me/app/ask-ada) 👉 Adaptiv Academy


### PR DESCRIPTION
Adds LLM Pulse to the SEO & Searching section.

LLM Pulse tracks brand mentions, citations, sentiment, and competitor share of voice across AI search engines. This matches the section's existing AI-search visibility tools, including RankRaven, SEOfor.AI, and Parse.

Canonical site: https://llmpulse.ai/

Disclosure: I am a co-founder of LLM Pulse.