### PR TITLE
Add IELTS Writing Practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,8 @@ Describe the problem your product/service solves. Help the bot with top level in
 
 249. [AnySlide](https://anyslide.app) 👉 AI slide deck generator with two engines: HTML inline-editable web slides and gpt-image-2 full-image rendering with native Chinese, Japanese, and Korean text support. 38 templates, 8 niche presets, 60 free credits at signup.
 
+250. [IELTS Writing Practice](https://ieltswritingpractice.app/) 👉 Free IELTS question bank and timed writing practice, with paid AI scores and criterion-specific feedback.
+
 ## 3. <a name='Dev'></a>💻 Dev
 
 1. [Adept](https://www.adept.ai/) 👉 ML research and product lab building general intelligence by enabling humans and computers to work together creatively.


### PR DESCRIPTION
Adds [IELTS Writing Practice](https://ieltswritingpractice.app/) to Writing. It combines a public IELTS question bank with timed drafting for Academic Task 1, General Training Task 1, and Task 2, plus optional AI feedback.

The public question bank and timed drafting are free. Submitting writing for AI score estimates and detailed corrections requires an account and paid plan.

Disclosure: I maintain IELTS Writing Practice and IELTS Writing Checker (ieltswritingchecker.org). This entry focuses on IELTS Writing Practice's question bank and timed drafting workflow; existing entries are preserved.

Validation: inspected the live homepage and pricing in Chrome, checked the proposed URL and name against the current repository, and ran `git diff --check`.
